### PR TITLE
Test/comment-children, ent.Comment => data.CommentOutput 변환 로직 개선

### DIFF
--- a/data/mapper/comment.go
+++ b/data/mapper/comment.go
@@ -7,6 +7,7 @@ import (
     "time"
 )
 
+// Author와 Children을 복제해서 Output으로 리턴
 func CommentModelToOutput(src *ent.Comment, dest *data.CommentOutput) *data.CommentOutput {
     if src == nil {
         return nil
@@ -26,7 +27,8 @@ func CommentModelToOutput(src *ent.Comment, dest *data.CommentOutput) *data.Comm
     dest.Content = src.Content
     dest.Kind = src.Kind
     dest.State = src.State
-    // children 처리 안함.
+    // children은 그냥 빈 배열로 저장.
+    // 필요한 경우
     dest.Children = []*data.CommentOutput{}
 
     return dest
@@ -34,6 +36,8 @@ func CommentModelToOutput(src *ent.Comment, dest *data.CommentOutput) *data.Comm
 
 func CopyCommentOutput(src *data.CommentOutput) *data.CommentOutput {
     dest := *src
+    copiedAuthor := *src.Author
+    dest.Author = &copiedAuthor
     dest.Children = make([]*data.CommentOutput, len(dest.Children))
 
     for i, child := range src.Children {

--- a/test/test.go
+++ b/test/test.go
@@ -178,7 +178,7 @@ func SetUpComments(client *ent.Client) {
 
 	Comment7SomebodyAnonymousFromComment1, err = client.Comment.Create().
 		SetArticleID(1).
-		SetAuthorID("jinsu").
+		SetAuthorID("somebody").
 		SetKind("anonymous").
 		SetContent("테스트로 작성한 somebody의 익명 코멘트").
 		SetParent(Comment1JinsuAnonymous).

--- a/usecase/comment.go
+++ b/usecase/comment.go
@@ -73,6 +73,31 @@ func (uc *CommentUseCase) Create(commentInput *data.CommentInput) (*data.Comment
 		SetContent(commentInput.Content).
 		SetState("exists").
 		Save(context.Background())
+	newComment = uc.Repo.Comment.Query().
+		// 댓글 작성자
+		WithAuthor().
+		WithArticle(func(query *ent.ArticleQuery) {
+			query.WithAuthor()
+		}).
+		WithStudyArticle(func(query *ent.StudyArticleQuery) {
+			query.WithAuthor()
+		}).
+		// 대댓글
+		WithChildren(
+			func(query *ent.CommentQuery) {
+				query.
+					WithAuthor().
+					WithArticle(func(query *ent.ArticleQuery) {
+						query.WithAuthor()
+					}).
+					WithStudyArticle(func(query *ent.StudyArticleQuery) {
+						query.WithAuthor()
+					})
+			},
+		).
+		Where(comment.ID(newComment.ID)).
+		OnlyX(context.TODO())
+
 	if err != nil {
 		logrus.Error(newComment, err)
 		return nil, err
@@ -86,7 +111,6 @@ func (uc *CommentUseCase) Create(commentInput *data.CommentInput) (*data.Comment
 
 func (uc *CommentUseCase) List(username string, opt *repository.CommentQueryOption) ([]*data.CommentOutput, error) {
 	logrus.WithField("username", username).Infof("Start List CommentQueryOption(%#v)", opt)
-	ctx := context.Background()
 	query := uc.Repo.Comment.Query()
 	if opt.AuthorUsername != "" {
 		query.Where(comment.HasAuthorWith(khumuuser.ID(opt.AuthorUsername)))
@@ -95,10 +119,10 @@ func (uc *CommentUseCase) List(username string, opt *repository.CommentQueryOpti
 		query.Where(comment.HasArticleWith(article.ID(opt.ArticleId)))
 	}
 
-	parents, err := query.
-		WithChildren().
+	parents, err := appendQueryForComment(query).
 		Where(comment.Not(comment.HasParent())).
-		All(ctx)
+		All(context.TODO())
+
 	if err != nil {
 		logrus.Errorf("comments 쿼리 도중 오류 발생. QueryOption(%+v)", opt)
 		return nil, err
@@ -118,17 +142,11 @@ func (uc *CommentUseCase) List(username string, opt *repository.CommentQueryOpti
 func (uc *CommentUseCase) Get(username string, id int) (*data.CommentOutput, error) {
 	logrus.WithField("username", username).Infof("Start Get Comment(id:%#v)", id)
 	ctx := context.Background()
-	comment, err := uc.Repo.Comment.Query().
-		WithAuthor(func(query *ent.KhumuUserQuery) {
-			query.Select(khumuuser.FieldID, khumuuser.FieldNickname, khumuuser.FieldState)
-		}).
-		WithChildren(func(query *ent.CommentQuery) {
-			query.WithAuthor(func(query *ent.KhumuUserQuery) {
-				query.Select(khumuuser.FieldID, khumuuser.FieldNickname, khumuuser.FieldState)
-			})
-		}).
+
+	comment, err := appendQueryForComment(uc.Repo.Comment.Query()).
 		Where(comment.ID(id)).
 		Only(ctx)
+
 	if err != nil {
 		logrus.Errorf("comment 쿼리 도중 오류 발생.")
 		return nil, err
@@ -142,14 +160,14 @@ func (uc *CommentUseCase) Get(username string, id int) (*data.CommentOutput, err
 func (uc *CommentUseCase) Update(username string, id int, opt map[string]interface{}) (*data.CommentOutput, error) {
 	logrus.WithField("username", username).WithField("id", id).Infof("Start Get CommentQueryOption(%#v)", opt)
 	ctx := context.Background()
-	comment, err := uc.Repo.Comment.Get(ctx, id)
+	commentExisting, err := uc.Repo.Comment.Get(ctx, id)
 	if err != nil {
 		logrus.Errorf("Comment(%d)를 찾는 도중 에러가 발생했습니다.", id)
 		return nil, err
 	}
 	// pk로 검색하게 하고 내용만 바꿔놓으면 저장 안 됨.
 	// JPA랑 다름.
-	updater := uc.Repo.Comment.UpdateOne(comment)
+	updater := uc.Repo.Comment.UpdateOne(commentExisting)
 
 	contentValue, contentExists := opt["content"]
 	if contentExists {
@@ -159,11 +177,14 @@ func (uc *CommentUseCase) Update(username string, id int, opt map[string]interfa
 	if kindExists {
 		updater.SetKind(kindValue.(string))
 	}
-	commentUpdated, err := updater.Save(ctx)
-
+	_, err = updater.Save(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	commentUpdated, err := appendQueryForComment(uc.Repo.Comment.Query()).
+		Where(comment.ID(id)).
+		Only(ctx)
 
 	output := uc.modelToOutput(username, commentUpdated, nil)
 	uc.hideFieldOfCommentOutput(username, output)
@@ -201,44 +222,16 @@ func (uc *CommentUseCase) Delete(username string, id int) error {
 	return nil
 }
 
-func (uc *CommentUseCase) listParentWithChildren(allComments []*data.CommentOutput) []*data.CommentOutput {
-	var parents []*data.CommentOutput
-
-	for _, comment := range allComments {
-		if comment.Parent == nil {
-			parents = append(parents, comment)
-		}
-	}
-	for _, comment := range allComments {
-		if comment.Parent != nil {
-
-		}
-	}
-
-	return parents
-}
-
 // CommentOutput.Children까지 재귀적으로 CommentOutput으로 만든다.
 // mapper의 단순 mapping 작업 뿐만 아니라 서비스 로직이 깃든다.
 // username: 요청자
 // comment: 원본 모델 댓글
 // output: 결과물 output 댓글. create if nil
 func (uc *CommentUseCase) modelToOutput(username string, comment *ent.Comment, outputRef *data.CommentOutput) *data.CommentOutput {
-	ctx := context.Background()
 	output := outputRef
 	if output == nil {
 		output = &data.CommentOutput{}
 	}
-
-	comment.Edges.StudyArticle = comment.QueryStudyArticle().WithAuthor(func(query *ent.KhumuUserQuery) {
-		query.Select(khumuuser.FieldID)
-	}).Select("id").FirstX(ctx)
-
-	comment.Edges.Article = comment.QueryArticle().WithAuthor(func(query *ent.KhumuUserQuery) {
-		query.Select(khumuuser.FieldID)
-	}).Select("id").FirstX(ctx)
-
-	comment.Edges.Author = comment.QueryAuthor().Select(khumuuser.FieldID, khumuuser.FieldNickname, khumuuser.FieldState).OnlyX(ctx)
 
 	mapper.CommentModelToOutput(comment, output)
 	if comment.Edges.Article != nil {

--- a/usecase/query.go
+++ b/usecase/query.go
@@ -1,0 +1,35 @@
+package usecase
+
+import "github.com/khu-dev/khumu-comment/ent"
+
+// 댓글 조회 시 기본적으로 필요한 query문을 추가한다.
+// 댓글 작성자
+// 게시물과 게시물의 작성자
+// 스터디 게시물과 스터디 게시물의 작성자
+// 대댓글도 마찬가지 과정
+func appendQueryForComment(query *ent.CommentQuery) *ent.CommentQuery{
+    query.
+		// 댓글 작성자
+		WithAuthor().
+		WithArticle(func(query *ent.ArticleQuery) {
+			query.WithAuthor()
+		}).
+		WithStudyArticle(func(query *ent.StudyArticleQuery) {
+			query.WithAuthor()
+		}).
+		// 대댓글
+		WithChildren(
+			func(query *ent.CommentQuery) {
+				query.
+					WithAuthor().
+					WithArticle(func(query *ent.ArticleQuery) {
+						query.WithAuthor()
+					}).
+					WithStudyArticle(func(query *ent.StudyArticleQuery) {
+						query.WithAuthor()
+					})
+			},
+		)
+
+    return query
+}


### PR DESCRIPTION
## Legacy

아무래도 댓글 같은 경우엔 댓글이 댓글을 포함하는 재귀적인 형태를 띄다보니 `CommentOutput`의 값을 변경하는 과정에서 많은 오류가 있었다. 왜냐하면 **struct를 제대로 복사하지 않고 같은 값을 참조하게 된다면 예를 들어 다음과 같은 버그**가 나타난 적이 많다.

1. 익명 댓글 Comment(id=1)의 author는 User(username=jinsu)
2. 기명 댓글 Comment(id=2)의 author는 User(username=jinsu)

일 때 **1번 댓글의 author를 `"jinsu"` 에서 `"익명"`으로 변경(hide)할 경우 2번 댓글의 author마저 변경**되어버리기 때문이다. 이러한 버그를 막기 위해서는 값을 안전하게 복사할 수 있는 작업이 필요할 것이다.

마찬가지로 부모 댓글의 author를 변경하면 자식 댓글의 author가 변경되는 경우도 있었다.

이러한 작업 속에서 댓글의 대댓글들을 변환하고 테스트하던 도중 로직이 혼란스럽다고 느꼈고, 추가적으로 로직도 개선했다.
`ent.Comment` 에서 `data.CommentOutput`으로 변경하는 로직이 문제였다. 왜냐하면 맵핑 작업에서 추가적으로 persistence layer에 접근하는 로직이 추가되어있었고, 불필요하게 쿼리문마다 필요한 필드를 지정했기 때문이다.

## 개선한 작업 내용

1. persistence layer에서 쿼리할 때 추후 view쪽에서 필요한 정보들도 모두 한 번에 쿼리한다. (기존엔 기본적인 필드들만 쿼리하고 entity => dto(여기선 `CommentOutput`)으로 변환할 때 필요한 필드들을 추가적으로 쿼리했음. 그러자 뭘 쿼리했는지, 왜 `nil`인지가 혼란스러워짐.)
2. `modelToOutput` 메소드는 persistence layer에서 필요한 모든 필드를 조회한 `ent.Comment`를 여러 로직을 수행하며 `data.CommentOutput`으로 1차적으로 변환해준다. 이렇게 변환된 `data.CommentOutput`은 내부적으로 마이크로서비스들이 메시지를 주고받을 때 이용하게 된다.
3. `hideFieldOfCommentOutput` 메소드는 댓글 정보 중 일반 유저들은 보지 말아야할 필드들을 가린다. 이 작업까지 수행하면 일반 유저들에게 response로 사용될 수 있다.

그리고 `ent`가 견고하고 편리한 기능들을 많이 제공해주는 반면, 쿼리할 때는 다소 필드 지정하는 것이 귀찮은 감이 있었는데 이를 그냥 하나의 함수로 정의해서 여러 곳에서 이용했다. `Java`라면 이런 애매한 함수는 어떤 객체에 넣어야할지 좀 난감했을 수 있는데, Go에서는 그냥 함수로 작성하면 되기 때문에 편하다. 단 너무 개별 함수들이 많아지면 관리하기 힘들 수도 있을 것 같다.
```go
// 댓글 조회 시 기본적으로 필요한 query문을 추가한다.
// 댓글 작성자
// 게시물과 게시물의 작성자
// 스터디 게시물과 스터디 게시물의 작성자
// 대댓글도 마찬가지 과정
func appendQueryForComment(query *ent.CommentQuery) *ent.CommentQuery{
    query.
		// 댓글 작성자
		WithAuthor().
		WithArticle(func(query *ent.ArticleQuery) {
			query.WithAuthor()
		}).
		WithStudyArticle(func(query *ent.StudyArticleQuery) {
			query.WithAuthor()
		}).
		// 대댓글
		WithChildren(
			func(query *ent.CommentQuery) {
				query.
					WithAuthor().
					WithArticle(func(query *ent.ArticleQuery) {
						query.WithAuthor()
					}).
					WithStudyArticle(func(query *ent.StudyArticleQuery) {
						query.WithAuthor()
					})
			},
		)

    return query
}
```